### PR TITLE
Hide-on-this-page

### DIFF
--- a/src/components/RightSidebar/TableOfContents.module.scss
+++ b/src/components/RightSidebar/TableOfContents.module.scss
@@ -1,4 +1,5 @@
 .toggle {
-	background-color: var(--bewebdev-pink-saturated);
+	background-color: var(--docs-btn-bg);
+	color: var(--docs-btn-text);
 	padding: 0.7rem 2rem;
 }

--- a/src/components/RightSidebar/TableOfContents.module.scss
+++ b/src/components/RightSidebar/TableOfContents.module.scss
@@ -1,0 +1,4 @@
+.toggle {
+	background-color: var(--bewebdev-pink-saturated);
+	padding: 0.7rem 2rem;
+}

--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -38,7 +38,6 @@ const TableOfContents: FunctionalComponent<{ headings: MarkdownHeading[] }> = ({
 	const setSummaryVisibleHandler = () => {
 		setIsVisible(true)
 		setTimeout(() => {
-			console.log(listRef.current)
 			listRef.current?.scrollIntoView({
 				behavior: 'smooth',
 				block: 'start',

--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -38,10 +38,22 @@ const TableOfContents: FunctionalComponent<{ headings: MarkdownHeading[] }> = ({
 	const setSummaryVisibleHandler = () => {
 		setIsVisible(true)
 		setTimeout(() => {
+			console.log(listRef.current)
 			listRef.current?.scrollIntoView({
 				behavior: 'smooth',
 				block: 'start',
 			})
+		}, 50)
+	}
+
+	const setSummaryHiddenHandler = () => {
+		setIsVisible(false)
+		setTimeout(() => {
+			const h2 = document.querySelector(
+				'h2.heading-wrapper'
+			) as HTMLHeadingElement
+			h2.style.scrollMarginTop = '100px'
+			h2?.scrollIntoView({ behavior: 'smooth', block: 'start' })
 		}, 50)
 	}
 
@@ -55,7 +67,7 @@ const TableOfContents: FunctionalComponent<{ headings: MarkdownHeading[] }> = ({
 	return (
 		<>
 			{width <= 769 && (
-				<button className={classes.toggle} onClick={() => setIsVisible(false)}>
+				<button className={classes.toggle} onClick={setSummaryHiddenHandler}>
 					Hide summary
 				</button>
 			)}

--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -48,9 +48,9 @@ const TableOfContents: FunctionalComponent<{ headings: MarkdownHeading[] }> = ({
 	const setSummaryHiddenHandler = () => {
 		setIsVisible(false)
 		setTimeout(() => {
-			const h2 = document.querySelector(
-				'h2.heading-wrapper'
-			) as HTMLHeadingElement
+			const h2 =
+				document.querySelector<HTMLHeadingElement>('h2.heading-wrapper')
+			if (!h2) return
 			h2.style.scrollMarginTop = '100px'
 			h2?.scrollIntoView({ behavior: 'smooth', block: 'start' })
 		}, 50)

--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -1,6 +1,7 @@
 import type { FunctionalComponent } from 'preact'
 import { useState, useEffect, useRef } from 'preact/hooks'
 import type { MarkdownHeading } from 'astro'
+import classes from './TableOfContents.module.scss'
 
 type ItemOffsets = {
 	id: string
@@ -10,11 +11,15 @@ type ItemOffsets = {
 const TableOfContents: FunctionalComponent<{ headings: MarkdownHeading[] }> = ({
 	headings = [],
 }) => {
+	const [isVisible, setIsVisible] = useState(true)
+	const [width, setWidth] = useState<number>(0)
 	const itemOffsets = useRef<ItemOffsets[]>([])
 	// FIXME: Not sure what this state is doing. It was never set to anything truthy.
+	const listRef = useRef<HTMLHeadingElement>(null)
 	const [activeId] = useState<string>('')
 	useEffect(() => {
 		const getItemOffsets = () => {
+			setWidth(window.innerWidth)
 			const titles = document.querySelectorAll('article :is(h1, h2, h3, h4)')
 			itemOffsets.current = Array.from(titles).map((title) => ({
 				id: title.id,
@@ -30,9 +35,33 @@ const TableOfContents: FunctionalComponent<{ headings: MarkdownHeading[] }> = ({
 		}
 	}, [])
 
+	const setSummaryVisibleHandler = () => {
+		setIsVisible(true)
+		setTimeout(() => {
+			listRef.current?.scrollIntoView({
+				behavior: 'smooth',
+				block: 'start',
+			})
+		}, 50)
+	}
+
+	if (!isVisible)
+		return (
+			<button className={classes.toggle} onClick={setSummaryVisibleHandler}>
+				Show summary
+			</button>
+		)
+
 	return (
 		<>
-			<h2 className='heading'>On this page</h2>
+			{width <= 769 && (
+				<button className={classes.toggle} onClick={() => setIsVisible(false)}>
+					Hide summary
+				</button>
+			)}
+			<h2 ref={listRef} style={{ scrollMargin: '100px' }} className='heading'>
+				On this page
+			</h2>
 			<ul>
 				<li
 					className={`heading-link ${

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -142,15 +142,15 @@ h5 {
 	}
 
 	h2 {
-		font-size: 1.2rem;
-	}
-
-	h3 {
 		font-size: 1.8rem;
 	}
 
-	h4 {
+	h3 {
 		font-size: 1.4rem;
+	}
+
+	h4 {
+		font-size: 1.2rem;
 	}
 
 	h5 {


### PR DESCRIPTION
# Added posibility to hide docs page summary list to skip to content fast
![obraz](https://user-images.githubusercontent.com/55458485/213826430-b94ae4d6-f526-48f1-b490-264ac4cbfa0e.png)
