### PR TITLE
Fix: change centering content style in docs button so it displays correctly on safari

### DIFF
--- a/src/components/LandingPage/DocsBtn.astro
+++ b/src/components/LandingPage/DocsBtn.astro
@@ -52,8 +52,9 @@ const css = `docs-btn ${glow ? 'glow' : ''} ${classes ? classes : ''}`
 	}
 
 	.docs-btn {
-		display: grid;
-		place-items: center;
+		display: flex;
+		justify-content: center;
+		align-items: center;
 		padding: 0.3rem;
 		font-size: 1.3rem;
 		color: var(--font-body);


### PR DESCRIPTION
# Before
![image](https://github.com/NowYouKnowProgramming/webdev-learning-materials/assets/55458485/a0a5908a-a441-4c8d-afd5-ce5c3683ee77)

# After
![image](https://github.com/NowYouKnowProgramming/webdev-learning-materials/assets/55458485/798effbf-1a85-4004-831b-c0fdb05cbf7b)
